### PR TITLE
Fix navigation links and typos on thoughts subpages

### DIFF
--- a/thoughts/11_december_2025.html
+++ b/thoughts/11_december_2025.html
@@ -3,13 +3,13 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Michael Ginn - Projects</title>
+        <title>Michael Ginn - Thoughts</title>
         <!-- <link
             href="http://fonts.googleapis.com/css?family=Open+Sans"
             rel="stylesheet"
             type="text/css"
         /> -->
-        <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+        <link rel="icon" type="image/x-icon" href="../assets/favicon.ico" />
         <link href="../styles/style.css" rel="stylesheet" type="text/css" />
         <link
             href="../styles/publications.css"
@@ -24,11 +24,18 @@
                 <!-- <div id="navbar-title-text">LECS Lab</div> -->
             </div>
             <div class="navbar-items">
-                <a href="index.html" class="navbar-item">home</a>
-                <a href="publications.html" class="navbar-item">publications</a>
-                <a href="projects.html" class="navbar-item">projects</a>
-                <a href="thoughts.html" class="navbar-item active">thoughts</a>
-                <a href="assets/cv.pdf" class="navbar-item" target="_blank"
+                <a href="../index.html" class="navbar-item">home</a>
+                <a href="../publications.html" class="navbar-item"
+                    >publications</a
+                >
+                <a href="../projects.html" class="navbar-item">projects</a>
+                <a href="../thoughts.html" class="navbar-item active"
+                    >thoughts</a
+                >
+                <a
+                    href="../assets/cv.pdf"
+                    class="navbar-item"
+                    target="_blank"
                     >cv</a
                 >
             </div>
@@ -39,9 +46,10 @@
             <p>
                 I've trained something like 50,000 small ML models so far in my
                 Ph.D. Often, I'm working at the absolute lowest scale
-                datasets--with as few as 100 examples for a difficult. My first
-                claim is that even in these settings, it is very possible to
-                train a non-random model, and likely even a pretty decent model.
+                datasets&mdash;with as few as 100 examples for a difficult task.
+                My first claim is that even in these settings, it is very
+                possible to train a non-random model, and likely even a pretty
+                decent model.
             </p>
             <p>
                 The first obvious step is to pick a nice strong base
@@ -86,7 +94,7 @@
                 Some architecture and training tricks are easy enough to
                 implement and worth it (tied embedding/unembedding, RoPE, beam
                 search, aggressive gradient clipping) others maybe aren't
-                (teaching forcing). Most of all, keep it simple! Formulate the
+                (teacher forcing). Most of all, keep it simple! Formulate the
                 inputs and outputs well so that the model has to learn as little
                 as possible.
             </p>

--- a/thoughts/13_march_2025.html
+++ b/thoughts/13_march_2025.html
@@ -3,13 +3,13 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Michael Ginn - Projects</title>
+        <title>Michael Ginn - Thoughts</title>
         <!-- <link
             href="http://fonts.googleapis.com/css?family=Open+Sans"
             rel="stylesheet"
             type="text/css"
         /> -->
-        <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+        <link rel="icon" type="image/x-icon" href="../assets/favicon.ico" />
         <link href="../styles/style.css" rel="stylesheet" type="text/css" />
         <link
             href="../styles/publications.css"
@@ -24,11 +24,18 @@
                 <!-- <div id="navbar-title-text">LECS Lab</div> -->
             </div>
             <div class="navbar-items">
-                <a href="index.html" class="navbar-item">home</a>
-                <a href="publications.html" class="navbar-item">publications</a>
-                <a href="projects.html" class="navbar-item">projects</a>
-                <a href="thoughts.html" class="navbar-item active">thoughts</a>
-                <a href="assets/cv.pdf" class="navbar-item" target="_blank"
+                <a href="../index.html" class="navbar-item">home</a>
+                <a href="../publications.html" class="navbar-item"
+                    >publications</a
+                >
+                <a href="../projects.html" class="navbar-item">projects</a>
+                <a href="../thoughts.html" class="navbar-item active"
+                    >thoughts</a
+                >
+                <a
+                    href="../assets/cv.pdf"
+                    class="navbar-item"
+                    target="_blank"
                     >cv</a
                 >
             </div>

--- a/thoughts/27_april_2025.html
+++ b/thoughts/27_april_2025.html
@@ -3,13 +3,13 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Michael Ginn - Projects</title>
+        <title>Michael Ginn - Thoughts</title>
         <!-- <link
             href="http://fonts.googleapis.com/css?family=Open+Sans"
             rel="stylesheet"
             type="text/css"
         /> -->
-        <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+        <link rel="icon" type="image/x-icon" href="../assets/favicon.ico" />
         <link href="../styles/style.css" rel="stylesheet" type="text/css" />
         <link
             href="../styles/publications.css"
@@ -24,11 +24,18 @@
                 <!-- <div id="navbar-title-text">LECS Lab</div> -->
             </div>
             <div class="navbar-items">
-                <a href="index.html" class="navbar-item">home</a>
-                <a href="publications.html" class="navbar-item">publications</a>
-                <a href="projects.html" class="navbar-item">projects</a>
-                <a href="thoughts.html" class="navbar-item active">thoughts</a>
-                <a href="assets/cv.pdf" class="navbar-item" target="_blank"
+                <a href="../index.html" class="navbar-item">home</a>
+                <a href="../publications.html" class="navbar-item"
+                    >publications</a
+                >
+                <a href="../projects.html" class="navbar-item">projects</a>
+                <a href="../thoughts.html" class="navbar-item active"
+                    >thoughts</a
+                >
+                <a
+                    href="../assets/cv.pdf"
+                    class="navbar-item"
+                    target="_blank"
                     >cv</a
                 >
             </div>
@@ -46,10 +53,10 @@
             <p>
                 On one hand, a majority (perhaps) of students are now producing
                 all of their code via an LLM app, which would certainly fall
-                under the restricions on the use of external resources.
+                under the restrictions on the use of external resources.
             </p>
             <p>
-                The said, LLMs are here to stay, and only getting harder to
+                That said, LLMs are here to stay, and only getting harder to
                 detect through any objective measure.
             </p>
             <p>
@@ -60,7 +67,7 @@
                 >
             </p>
             <p>
-                My take is that we already have an analagous pedagogical model:
+                My take is that we already have an analogous pedagogical model:
                 mathematics education.
             </p>
             <p>
@@ -77,7 +84,7 @@
                 (as affectionately it is known) can whiz through any CS
                 assignment for like 90% of classes. After all, that's
                 essentially the
-                <i>main thing it was traind to do (w.r.t. coding).</i> Think
+                <i>main thing it was trained to do (w.r.t. coding).</i> Think
                 about the format of a coding instruct prompt--"Write a function
                 that..."--that is essentially the same as a homework prompt.
                 <b
@@ -86,7 +93,7 @@
                 >
             </p>
             <p>
-                Anyways, the obvious solution is to reweigh how we do grading,
+                Anyways, the obvious solution is to reweight how we do grading,
                 and massively upweight exams, and make it clear to students that
                 they don't have to work hard on their homeworks, but it will
                 cost them come exam.

--- a/thoughts/7_march_2025.html
+++ b/thoughts/7_march_2025.html
@@ -3,13 +3,13 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Michael Ginn - Projects</title>
+        <title>Michael Ginn - Thoughts</title>
         <!-- <link
             href="http://fonts.googleapis.com/css?family=Open+Sans"
             rel="stylesheet"
             type="text/css"
         /> -->
-        <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+        <link rel="icon" type="image/x-icon" href="../assets/favicon.ico" />
         <link href="../styles/style.css" rel="stylesheet" type="text/css" />
         <link
             href="../styles/publications.css"
@@ -24,11 +24,18 @@
                 <!-- <div id="navbar-title-text">LECS Lab</div> -->
             </div>
             <div class="navbar-items">
-                <a href="index.html" class="navbar-item">home</a>
-                <a href="publications.html" class="navbar-item">publications</a>
-                <a href="projects.html" class="navbar-item">projects</a>
-                <a href="thoughts.html" class="navbar-item active">thoughts</a>
-                <a href="assets/cv.pdf" class="navbar-item" target="_blank"
+                <a href="../index.html" class="navbar-item">home</a>
+                <a href="../publications.html" class="navbar-item"
+                    >publications</a
+                >
+                <a href="../projects.html" class="navbar-item">projects</a>
+                <a href="../thoughts.html" class="navbar-item active"
+                    >thoughts</a
+                >
+                <a
+                    href="../assets/cv.pdf"
+                    class="navbar-item"
+                    target="_blank"
                     >cv</a
                 >
             </div>
@@ -44,8 +51,9 @@
                 almost seem to go infinitely smaller—a fractal.
             </p>
             <p>
-                Now the expert, you can fill a book with your knowledge about
-                the snowflake. Turns out, others have written their own books on
+                Now, as the expert, you can fill a book with your knowledge
+                about the snowflake. Turns out, others have written their own
+                books on
                 their own snowflakes, and browsing through them you can find
                 patterns that look the same as yours. You might even devote your
                 life to reading these books and sorting the snowflakes into

--- a/thoughts/8_april_2025.html
+++ b/thoughts/8_april_2025.html
@@ -3,13 +3,13 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Michael Ginn - Projects</title>
+        <title>Michael Ginn - Thoughts</title>
         <!-- <link
             href="http://fonts.googleapis.com/css?family=Open+Sans"
             rel="stylesheet"
             type="text/css"
         /> -->
-        <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+        <link rel="icon" type="image/x-icon" href="../assets/favicon.ico" />
         <link href="../styles/style.css" rel="stylesheet" type="text/css" />
         <link
             href="../styles/publications.css"
@@ -24,11 +24,18 @@
                 <!-- <div id="navbar-title-text">LECS Lab</div> -->
             </div>
             <div class="navbar-items">
-                <a href="index.html" class="navbar-item">home</a>
-                <a href="publications.html" class="navbar-item">publications</a>
-                <a href="projects.html" class="navbar-item">projects</a>
-                <a href="thoughts.html" class="navbar-item active">thoughts</a>
-                <a href="assets/cv.pdf" class="navbar-item" target="_blank"
+                <a href="../index.html" class="navbar-item">home</a>
+                <a href="../publications.html" class="navbar-item"
+                    >publications</a
+                >
+                <a href="../projects.html" class="navbar-item">projects</a>
+                <a href="../thoughts.html" class="navbar-item active"
+                    >thoughts</a
+                >
+                <a
+                    href="../assets/cv.pdf"
+                    class="navbar-item"
+                    target="_blank"
                     >cv</a
                 >
             </div>
@@ -37,7 +44,7 @@
             <a href="../thoughts.html">Back</a>
             <h3 id="april-8-2025">8 april 2025</h3>
             <p>
-                The most important thing about llms is that they give something
+                The most important thing about LLMs is that they give something
                 <i>shaped like an answer</i>.
             </p>
             <p>
@@ -61,18 +68,18 @@
             </p>
             <p>
                 Importantly, this holds for virtually any task that you can
-                formulate in language. You can ask an llm to do composition,
+                formulate in language. You can ask an LLM to do composition,
                 text editing, coding, question answering, etc...even weird stuff
-                like igt generation. If you don't actually check the quality of
+                like IGT generation. If you don't actually check the quality of
                 the results, then you'd easily conclude you have an omniscient
                 autonomous program. However, if you check the quality of the
                 results, you often find they are actually far worse than
-                standard sota neural models.
+                standard SOTA neural models.
             </p>
             <p>
-                This is not a criticism of llms, which are being used for a
+                This is not a criticism of LLMs, which are being used for a
                 million tasks far from their original purpose. It is, however, a
-                clear risk for how people use llms. Any time a user unknowingly
+                clear risk for how people use LLMs. Any time a user unknowingly
                 performs a fairly out-of-domain task, they likely receive very
                 low-quality results, but results that are well-formatted and
                 plausible. If users are not clearly aware of what the program is


### PR DESCRIPTION
## Summary
- update thought subpages to use correct relative navigation links, favicon, and CV references
- fix typos and wording issues across dated thought entries

## Testing
- not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a995c453c832b89c3beafc7a09293)